### PR TITLE
Handling input

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -261,29 +261,6 @@ bool					connection::is_content_length_completed(fd_info &clnt_info, request &rq
 	return (true);
 }
 
-void					connection::parse_client_te_body(fd_info &clnt_info, request &rq)
-{
-	size_t	last = 0;
-	size_t	next = 0;
-	size_t	len;
-	std::string	res("");
-
-	//2\r\n
-	//hi\r\n -> 이런 식으로 문자열 길이, 문자열 순으로 들어오는 transfer-encoding: chunked일 때의 파싱
-	while ((next = clnt_info.msg.find("\n", last)) != std::string::npos)
-	{		
-		if (!(len = stoi(clnt_info.msg.substr(last, next - last)))) //c++11?
-			break ;
-		if (last)
-			res.append("\n");
-		last = next + 1;
-		res.append(clnt_info.msg.substr(last, len));
-		last += (len + 1);
-	}	
-	request::iterator it = rq.find_clnt_in_tmp(clnt_info.fd);
-	rq.insert(it, res);
-}
-
 int						connection::body_length(std::string msg)
 {
 	size_t	newline_num = 0;

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -41,12 +41,13 @@ class fd_info
 public:
 	int							fd; //현재 파일디스크립터
 	int							server_sock; //이 fd가 클라이언트라면 연결된 서버fd를 의미, 서버라면 -1 -> 나중에 연결된 서버 페이지를 보여준다던가 할 때 사용하려고 일단 fd를 넣고 해당 config 내용이 필요하다면 나중에 수정
+	std::string					tmp; //transfer-encoding 때 파싱한 문자열을 저장할 임시 문자열
 	std::string					msg; //이 fd가 클라이언트라면 입력받은 문자열을 받아서 나중에 \n 기준으로 split_msg에 추가
 	std::vector<std::string>	split_msg;
 	int							body_flag;
 
-	fd_info(int f) : fd(f), server_sock(-1), msg(""), split_msg(), body_flag(HEADER_NOT_PARSED) {}
-	fd_info(int f, int s) : fd(f), server_sock(s), msg(""), split_msg(), body_flag(HEADER_NOT_PARSED) {}
+	fd_info(int f) : fd(f), server_sock(-1), tmp(""), msg(""), split_msg(), body_flag(HEADER_NOT_PARSED) {}
+	fd_info(int f, int s) : fd(f), server_sock(s), tmp(""), msg(""), split_msg(), body_flag(HEADER_NOT_PARSED) {}
 };
 
 class connection
@@ -76,7 +77,7 @@ public:
 	bool						is_transfer_encoding_completed(fd_info &clnt_info, request &rq);
 	bool						is_content_length_completed(fd_info &clnt_info, request &rq);
 	void						parse_client_te_body(fd_info &clnt_info, request &rq);
-	int							cl_body_length(std::string &msg);
+	int							body_length(std::string msg);
 	void						print_client_msg(int clnt_sock);
 
 	class	socket_error : public std::exception

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -71,11 +71,12 @@ public:
 	void						get_client_msg(int clnt_sock, request &rq);
 	void						concatenate_client_msg(fd_info &clnt_info, std::string to_append);
 	void						parse_client_header_by_line(fd_info &clnt_info);
-	void						parse_client_body(fd_info &clnt_info, request &rq);
 	bool						is_input_completed(fd_info &clnt_info, request &rq);
 	void						is_body_exist(fd_info &clnt_info, request::iterator &it, request &rq);
 	bool						is_transfer_encoding_completed(fd_info &clnt_info, request &rq);
 	bool						is_content_length_completed(fd_info &clnt_info, request &rq);
+	void						parse_client_te_body(fd_info &clnt_info, request &rq);
+	int							cl_body_length(std::string &msg);
 	void						print_client_msg(int clnt_sock);
 
 	class	socket_error : public std::exception

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -76,7 +76,6 @@ public:
 	void						is_body_exist(fd_info &clnt_info, request::iterator &it, request &rq);
 	bool						is_transfer_encoding_completed(fd_info &clnt_info, request &rq);
 	bool						is_content_length_completed(fd_info &clnt_info, request &rq);
-	void						parse_client_te_body(fd_info &clnt_info, request &rq);
 	int							body_length(std::string msg);
 	void						print_client_msg(int clnt_sock);
 

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -13,10 +13,11 @@
 # include "request.hpp"
 
 # define	BUF_SIZE 			100
-# define	HEADER_NOT_PARSED	0
-# define	NO_BODY				1
-# define	TRANSFER_ENCODING	2
-# define	CONTENT_LENGTH		3
+# define	RQ_LINE_NOT_PARSED	0
+# define	HEADER_NOT_PARSED	1
+# define	NO_BODY				2
+# define	TRANSFER_ENCODING	3
+# define	CONTENT_LENGTH		4
 
 //읽고 쓸 때 체크해야 하는 fd 배열의 집합 - select에서 사용하나 서버 소켓에 대해 해당 read_fd를 활성화해줘야 하기 때문에 connection에서 선언
 class IO_fd_set
@@ -44,10 +45,10 @@ public:
 	std::string					tmp; //transfer-encoding 때 파싱한 문자열을 저장할 임시 문자열
 	std::string					msg; //이 fd가 클라이언트라면 입력받은 문자열을 받아서 나중에 \n 기준으로 split_msg에 추가
 	std::vector<std::string>	split_msg;
-	int							body_flag;
+	int							status;
 
-	fd_info(int f) : fd(f), server_sock(-1), tmp(""), msg(""), split_msg(), body_flag(HEADER_NOT_PARSED) {}
-	fd_info(int f, int s) : fd(f), server_sock(s), tmp(""), msg(""), split_msg(), body_flag(HEADER_NOT_PARSED) {}
+	fd_info(int f) : fd(f), server_sock(-1), tmp(""), msg(""), split_msg(), status(RQ_LINE_NOT_PARSED) {}
+	fd_info(int f, int s) : fd(f), server_sock(s), tmp(""), msg(""), split_msg(), status(RQ_LINE_NOT_PARSED) {}
 };
 
 class connection
@@ -71,6 +72,7 @@ public:
 	void						disconnect_client(int clnt_sock);
 	void						get_client_msg(int clnt_sock, request &rq);
 	void						concatenate_client_msg(fd_info &clnt_info, std::string to_append);
+	bool						parse_rq_line(fd_info &clnt_info, request &rq);
 	void						parse_client_header_by_line(fd_info &clnt_info);
 	bool						is_input_completed(fd_info &clnt_info, request &rq);
 	void						is_body_exist(fd_info &clnt_info, request::iterator &it, request &rq);

--- a/include/request.hpp
+++ b/include/request.hpp
@@ -60,6 +60,14 @@ public:
 	bool		is_existing_header(iterator &it, std::string header);
 	std::string	corresponding_header_value(iterator &it, std::string header);
 	bool		set_error(iterator &it, int err_no);
+
+	class	invalid_header_error : public std::exception
+	{
+		virtual const char	*what(void) const throw()
+		{
+			return ("Invalid Header!!");
+		}
+	};
 };
 
 #endif

--- a/include/request.hpp
+++ b/include/request.hpp
@@ -4,6 +4,7 @@
 # include <iostream>
 # include <string>
 # include <cstring>
+# include <algorithm>
 # include <vector>
 # include <map>
 

--- a/include/request.hpp
+++ b/include/request.hpp
@@ -68,6 +68,13 @@ public:
 			return ("Invalid Header!!");
 		}
 	};
+	class	incorrect_body_length_error : public std::exception
+	{
+		virtual const char	*what(void) const throw()
+		{
+			return ("Incorrect Body Length!!");
+		}
+	};
 };
 
 #endif

--- a/include/request.hpp
+++ b/include/request.hpp
@@ -8,9 +8,6 @@
 # include <vector>
 # include <map>
 
-# define	TMP_RQ	0
-# define	RQ		1
-
 class base_request
 {
 public:
@@ -49,10 +46,10 @@ public:
 	bool		is_invalid(iterator it);
 	void		print(void);
 	void		print_tmp(void);
-	iterator	insert_header(int clnt_fd, std::vector<std::string> msg_header);
+	iterator	insert_rq_line(int clnt_fd, std::string rq_line);
+	iterator	insert_header(iterator &it, std::vector<std::string> msg_header);
 	iterator	insert(iterator &it, std::string msg_body);
-	void		erase(iterator it);
-	second_type	parse_header(first_type &first, std::vector<std::string> msg);
+	void		erase(iterator &it);
 	iterator	find_clnt(int clnt_fd);
 	iterator	find_clnt_in_tmp(int clnt_fd);
 	bool		check_info_invalid(first_type &first);

--- a/include/request.hpp
+++ b/include/request.hpp
@@ -7,6 +7,9 @@
 # include <vector>
 # include <map>
 
+# define	TMP_RQ	0
+# define	RQ		1
+
 class base_request
 {
 public:
@@ -15,8 +18,9 @@ public:
 	std::string	url;
 	std::string	version;
 	bool		is_invalid;
+	int			err_no;
 
-	base_request(int fd_) : fd(fd_), method(""), url(""), version(""), is_invalid(false) {}
+	base_request(int fd_) : fd(fd_), method(""), url(""), version(""), is_invalid(false), err_no(-1) {}
 
 	bool	operator<(const base_request &base) const
 	{
@@ -33,20 +37,29 @@ public:
 	typedef std::vector<value_type>				value_arr;
 	typedef value_arr::iterator					iterator;
 private:
+	value_arr	tmp_rq;
 	value_arr	rq; //각 요청 메세지를 맵 형태로 저장 - 현재 처리가 필요한 요청들만 저장해뒀다가 처리해준 뒤 삭제
 public:
-	request(void) : rq() {}
+	request(void) : tmp_rq(), rq() {}
 	~request(void) {}
 	iterator	rq_begin(void);
 	iterator	rq_end(void);
 	bool		empty(void) const;
 	bool		is_invalid(iterator it);
 	void		print(void);
-	void		insert(int clnt_fd, std::vector<std::string> msg);
+	void		print_tmp(void);
+	iterator	insert_header(int clnt_fd, std::vector<std::string> msg_header);
+	iterator	insert(iterator &it, std::string msg_body);
 	void		erase(iterator it);
-	second_type	parse(first_type &first, std::vector<std::string> msg);
+	second_type	parse_header(first_type &first, std::vector<std::string> msg);
+	iterator	find_clnt(int clnt_fd);
+	iterator	find_clnt_in_tmp(int clnt_fd);
 	bool		check_info_invalid(first_type &first);
 	bool		check_header_invalid(second_type &second);
+	bool		which_method(iterator &it, std::string method);
+	bool		is_existing_header(iterator &it, std::string header);
+	std::string	corresponding_header_value(iterator &it, std::string header);
+	bool		set_error(iterator &it, int err_no);
 };
 
 #endif


### PR DESCRIPTION
1. 입력을 받으면서 Transfer-Encoding, Content-Length 헤더 존재 여부에 따라 본문을 더 받을지 결정하도록 수정
- 헤더 검사 전 메서드에 조건문 +
  - 구현해야 하는 메서드 중 GET, DELETE는 본문이 필요없기 때문에 POST일 경우에만 본문을 받을 수 있음. 
  - 조건부 GET? 요청이 뭔지는 아직 잘 모르곘지만 그때 본문을 받을 수 있는 경우도 있는 것 같은데 그건 나중에 메서드 작동시키는 거 보면서 수정하도록 하겠습니다!
- 개행이 포함된 문자열의 길이라고 할 지라도 길이를 계산해서 입력받을 수 있도록 함. 
- httpbin.org을 telnet으로 접속해서 확인한 결과랑 비교해서 코드 작성
  - Transfer-Encoding, Content-Length 헤더 둘 다 주지 않을 때는 본문 받지 않고 종료
  - RFC에서 Transfer-Encoding, Content-Length 둘 다 요청으로 주면 안 된다고 해서 에러 처리를 해줘야 하나 싶었는데 막상 테스트해보니 에러는 나지 않고 Transfer-Encoding으로 처리하길래 동일하게 작동하도록 했습니다!

2. 요청 시 request line에 문제가 있으면 바로 입력 종료하도록 수정
- telnet으로 확인해보니까 request line 잘못 주면 바로 작동을 중지하길래 구조만 더 고치면 될 것 같아서 수정했습니다! 

3. 그 외 잡다구리들
- 헤더 value 양옆 선택적 공백 제거해서 저장
- 헤더 key 소문자로 통일해서 저장
- request 내부 is_existing_header, corresponding_header_value 함수를 추가
  - is_existing_header: 인자로 들어온 헤더가 해당 iterator 내부에 존재하는지 확인
  - corresponding_header_value: 인자로 들어온 헤더에 대한 value값 반환(헤더가 이미 내부에 있다는 가정 하에 사용)
- 저번 회의에서 말씀드렸다시피 request에 자료 저장할 때 first_type 내부 err_no로 요청 메시지 유효하지 않을 때 에러 넘버 지정 가능하고 request 내부 set_error 메서드로 에러 넘버 지정 가능합니다!
-> 뭐 별 건 없지만 혹시 요청 메세지 처리하다가 필요하실까봐 적어놨습니다🙄 참고하세요!