### PR TITLE
설정파일 파싱 및 webserv 기능 추가

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -26,7 +26,7 @@ connection::connection(fd_set &rfds) : server_size(0), fd_arr(), read_fds(rfds)
 
 connection::~connection(void)
 {
-	for (int i = 0; i < server_size; i++)
+	for (int i = 0; i < fd_arr.size(); i++)
 		close(fd_arr[i].fd);
 }
 

--- a/exec_request.cpp
+++ b/exec_request.cpp
@@ -618,8 +618,7 @@ void    exec_request(config &cf, fd_set &write_fds, request *rq, std::string &re
 	    if (!rq->is_invalid(it)) //일단 그 값이 유효할 때만 출력 -> 나중에         유효하지 않으면 해당되는 에러 페이지 호출하도록
 	        rq->print();
 		try{
-			
-      (cf, *it, cf_i, m_mt);
+      			exec_header(cf, *it, cf_i, m_mt);
 			exec_method(cf, it, cf_i);
 			exec_body();
 			throw 200;

--- a/exec_request.cpp
+++ b/exec_request.cpp
@@ -1,14 +1,26 @@
 #include <iostream>
-#include <sys/select.h> /* According to earlier standards */ 
-#include <sys/time.h> 
-#include <sys/types.h> 
-#include <unistd.h>
 #include <exception>
+#include <iostream>
+#include <string>
+#include <algorithm>    // std::replace
 #include "./include/request.hpp"
 #include "./include/connection.hpp"
 #include "./include/exec_request.hpp"
 #include "./include/parsing.hpp"
 #include "./include/error.hpp"
+
+#include <sys/select.h> /* According to earlier standards */ 
+#include <sys/time.h> 
+#include <sys/types.h> 
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+//#include <io.h>
+
 void make_map_mime_types (std::map<std::string, std::string > &m_mt, std::string readLine)
 {
 	int flag = 0;
@@ -95,79 +107,170 @@ void set(std::map<int, std::string> &m_state_code, std::map<std::string, std::st
 		throw open_fail();
 	}
 }
-void exec_method(config &cf, request::iterator rq_iter)
-{
-	if(rq_iter->first.version != "HTTP/1.1")
-	{
-		throw 400;
-	}
-	if(rq_iter->first.method == "GET")
-	{
-		//std::cout << "GET" << std::endl;
-	}
-	else if(rq_iter->first.method == "POST")
-	{
-		//std::cout << "POST" << std::endl;
-	}
-	else if(rq_iter->first.method == "DELETE")
-	{
-		//std::cout << "DELETE" << std::endl;
-	}
-	else
-	{
-		throw 400;
-	}
-}
+
+
+
 
 class conf_index {
 	public : 
 		int server;
 		int location;
+		bool autoindex_flag;
 
 		std::string Connection;
 		std::string file_type;
 		std::string location_path;
 		std::string root_path;
 		std::string file_path;
+		std::string redirect_path;
+		std::string request_url;
+		std::string request_url_remaining;
+		std::map <std::string, std::string> m_qurry_string;
 
 	conf_index() {
 		server = -1;
 		location = -1;
+		autoindex_flag = false;
 
 		root_path = "";
 		location_path = "";
 		file_type = "text/html";
 		Connection = "keep-alive";
 		file_path = "";
+		redirect_path = "";
+		request_url = "";
+		request_url_remaining = "";
 	}
 };
 
+void exec_method(config &cf, request::iterator rq_iter, conf_index &cf_i)
+{
+	int flag = 0;
+	if(rq_iter->first.version != "HTTP/1.1")
+		throw 400;
+    if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("allow_methods") == cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
+		flag = 1;
+
+	if(flag == 1 || find (cf.v_s[cf_i.server].v_l[cf_i.location].m_location["allow_methods"].begin(), cf.v_s[cf_i.server].v_l[cf_i.location].m_location["allow_methods"].end(), rq_iter->first.method) != cf.v_s[cf_i.server].v_l[cf_i.location].m_location["allow_methods"].end())
+	{
+		if(rq_iter->first.method == "GET")
+		{
+			//std::cout << "GET" << std::endl;
+		}
+		else if(rq_iter->first.method == "POST")
+		{
+			//std::cout << "POST" << std::endl;
+		}
+		else if(rq_iter->first.method == "DELETE")
+		{
+			//std::cout << "DELETE" << std::endl;
+		}
+		else
+		{
+			throw 400;
+		}
+	}
+	else
+	{
+		std::cout << "이거 타는거 같은데? " <<std::endl;
+		throw 403;
+	}
+}
+
+
+void	parsing_url(config &cf, request::value_type &fd_data, conf_index &cf_i)
+{
+//	std::cout << "url :test  ==== " <<  fd_data.first.url << std::endl;
+	std::string tmp = "";
+	std::string key_tmp = "";
+	int save_flag = 0;
+	for(int i = 0; i < fd_data.first.url.size(); i++)
+	{
+		tmp +=  fd_data.first.url[i];
+		if((i + 1 == fd_data.first.url.size() && save_flag == 0) || (fd_data.first.url[i + 1] == '?' && save_flag == 0))
+		{
+			cf_i.request_url = tmp;
+			save_flag = 1;
+			tmp = "";
+			i = i + 1;
+		}
+		else if(save_flag == 1 && (i + 1 == fd_data.first.url.size() || fd_data.first.url[i + 1] == '=') )
+		{
+			save_flag = 2;
+			key_tmp = tmp;
+			tmp = "";
+			i = i + 1;
+		}
+		else if(save_flag == 2  && (i + 1 == fd_data.first.url.size() || (i + 2 < fd_data.first.url.size() && (fd_data.first.url[i + 1] == '&'  && fd_data.first.url[i + 2] == '&'))))
+		{
+			save_flag = 1;
+			cf_i.m_qurry_string[key_tmp] = tmp;
+			key_tmp = "";
+			tmp = "";
+			i = i + 2;
+		}
+	}
+
+// qurrystring
+//	std::cout << " ======-====== " << std::endl;
+//	std::cout << " ======-====== " << std::endl;
+//	std::cout << " cf_i.request_url : "  << cf_i.request_url << std::endl;
+//	for(std::map<std::string, std::string>::iterator it = cf_i.m_qurry_string.begin();  it != cf_i.m_qurry_string.end(); it++)
+//		std::cout <<"first : "<<  it->first << " second : " << it->second <<std::endl;
+//	std::cout << " ======-====== " << std::endl;
+//	std::cout << " ======-====== " << std::endl;
+
+
+}
+
+int my_compare_string(std::string tmp1, std::string tmp2)
+{
+	//tmp1만큼만 비교,
+	if(tmp1.size() > tmp2.size())
+		return 0;
+	for(int i = 0; i < tmp1.size(); i++)
+	{
+		if(tmp1[i] != tmp2[i])
+			return 0;
+	}
+	return 1;
+}
+
 void find_cf_location_i(config &cf, request::value_type &fd_data, conf_index &cf_i)
 {
-	if(0 == cf.v_s[cf_i.server].location_path.size())
-		throw config_error_location();
+	int same_value = 0;
+	parsing_url(cf, fd_data,cf_i);
+
 	for(int i = 0; i < cf.v_s[cf_i.server].location_path.size(); i++)
 	{
-		if(cf.v_s[cf_i.server].location_path[i] == fd_data.first.url)
+//		std::cout <<  cf.v_s[cf_i.server].location_path[i] << "  ::::  " << cf_i.request_url  << " size : " <<cf.v_s[cf_i.server].location_path[i].size() << " compare : " << cf.v_s[cf_i.server].location_path[i].compare(0,  cf.v_s[cf_i.server].location_path[i].size(), cf_i.request_url) << "    :" << cf.v_s[cf_i.server].location_path[i][0] << ":    :"<<cf_i.request_url[0] << ":" <<  std::endl;
+		if(my_compare_string(cf.v_s[cf_i.server].location_path[i], cf_i.request_url) == 1)
 		{
-			cf_i.location = i;
-			cf_i.location_path = cf.v_s[cf_i.server].location_path[i];
-			break;
+			if(cf.v_s[cf_i.server].location_path[i].size() == 1 || (cf_i.request_url.size() == cf.v_s[cf_i.server].location_path[i].size()) || cf_i.request_url[cf.v_s[cf_i.server].location_path[i].size()] == '/')
+			{
+				if(same_value < cf.v_s[cf_i.server].location_path[i].size())
+				{
+					same_value = cf.v_s[cf_i.server].location_path[i].size();
+					cf_i.location = i;
+					cf_i.location_path = cf.v_s[cf_i.server].location_path[i];
+				}
+			}
 		}
 		if(i + 1 == cf.v_s[cf_i.server].location_path.size())
 		{
+			if (same_value != 0)
+				break;
 			//std::cout << "에러처리찾기 :  error 404 loaction  못찾음 : " << fd_data.first.url<< std::endl;
 			// /favicon.ico 이것도 처리해줘야함...
 			throw 404;
 		}
 	}
+	if(cf_i.location_path.size() < cf_i.request_url.size())
+		cf_i.request_url_remaining = cf_i.request_url.substr(cf_i.location_path.size());
 }
 
 void find_cf_server_i(config &cf, request::value_type &fd_data, conf_index &cf_i)
 {
-	// conf 파일에 server가 없을떄
-	if(cf.v_s.size() == 0)
-		throw config_error_server();
 	for(int i = 0; i < cf.v_s.size(); i++)
 	{
 		if(cf.v_s[i].listen == fd_data.second["Host"])
@@ -177,8 +280,13 @@ void find_cf_server_i(config &cf, request::value_type &fd_data, conf_index &cf_i
 		}
 		if(i + 1 == cf.v_s.size())
 		{
+			cf_i.server = 0;
+			std::cout << "cf.v_s[i].listen : " << cf.v_s[i].listen <<std::endl;
+			std::cout << "fd_data.second[\"Host\"]" << fd_data.second["Host"] << std::endl;
 			std::cout << "에러처리찾기 : error server가 없으므로 에러 뛰워야함." << std::endl;
-			throw 404;
+			break;
+			// 일치하는 Host없으면 첫번째 server가 디폴트 server임.
+			//throw 404;
 		}
 	}
 }
@@ -193,14 +301,10 @@ void when_host_is_localhost(request::value_type &fd_data)
 	}
 }
 
-
-void confirmed_root_path(config &cf, conf_index &cf_i)
+std::string confirmed_root_path(config &cf, conf_index &cf_i)
 {
 	if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("root") != cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
 	{
-		if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["root"].size() != 1)
-			throw config_error_root();
-		else
 			cf_i.root_path = cf.v_s[cf_i.server].v_l[cf_i.location].m_location["root"][0];
 	}
 	else
@@ -209,8 +313,101 @@ void confirmed_root_path(config &cf, conf_index &cf_i)
 		cf.v_s[cf_i.server].v_l[cf_i.location].m_location["root"].push_back("./html_file");
 		cf_i.root_path = cf.v_s[cf_i.server].v_l[cf_i.location].m_location["root"][0];
 	}
+
+	std::string path = cf_i.root_path + cf_i.request_url_remaining;
+	struct stat s;
+	if( stat(path.c_str(),&s) == 0 )
+	{
+		if( s.st_mode & S_IFREG )
+		{
+			cf_i.file_path = path;
+			return "location is file";
+		}
+		else //( s.st_mode & S_IFDIR )
+			return "location is folder";
+	}
+	else
+		throw 404;
+
+//	DIR * dir = NULL;
+//	std::string path = cf_i.root_path + cf_i.request_url_remaining;
+//	std::cout << "path : " << path << std::endl;
+//	std::string path_list = "";
+//	if( (dir = opendir(path.c_str())) == NULL)
+//	{
+//		std::cout << "root, location 경로 잘못됨.!!! " <<  std::endl;
+//		throw 404;
+//	}
+//	closedir(dir);
+
+//	char* filename = "COOL"; // 여기에 파일이나 폴더명 입력
+
 }
 
+int check_filesize(std::ifstream &readFile, conf_index &cf_i, config &cf)
+{
+	std::streampos begin, end;
+	begin = readFile.tellg();
+	readFile.seekg (0, std::ios::end);
+	end = readFile.tellg();
+	readFile.close();
+	if(cf_i.location != -1 && cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("client_max_body_size") != cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
+	{
+		if(stol(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["client_max_body_size"][0]) * 1048576 < end - begin)
+		return 413;
+	}		
+	//std::cout << "###########size is: " << (end-begin) << " bytes.\n";
+	return 0;
+}
+
+void confirmed_file_path_and_file_type(config &cf, conf_index &cf_i, std::map<std::string, std::string> &m_mt)
+{
+	if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("index") == cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
+		cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"].push_back("index.html");
+	//std::cout << "server : " << cf_i.server << "   location : " << cf_i.location << std::endl;
+	for(int cnt = 0; cnt < cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"].size(); cnt++)
+	{
+		cf_i.file_path = cf_i.root_path + cf_i.request_url_remaining + "/" +  cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt];
+		std::ifstream readFile( cf_i.file_path.c_str() );
+		if (readFile.is_open())
+		{
+			if(413 == check_filesize(readFile, cf_i, cf))
+				throw 413;
+			//readFile.close()
+			//std::cout << "파일이 존재 합니다." << std::endl;
+			for(int str_i = cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt].size() - 1; str_i > 0; str_i--)
+			{
+				if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt][str_i] == '.')
+				{
+					if(m_mt.find(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt].substr(str_i + 1)) != m_mt.end())
+					{
+						cf_i.file_type = m_mt[cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt].substr(str_i + 1)];
+						break;
+					}
+					else
+						throw 400;
+				}
+			}
+			break;		
+		}
+		if (cnt + 1 == cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"].size())
+		{
+			if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("auto_index") != cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end() && cf.v_s[cf_i.server].v_l[cf_i.location].m_location["auto_index"][0] == "on")
+				cf_i.autoindex_flag = 1;
+			else throw 404;
+		}
+	}
+}
+
+void exec_redirection(config &cf, conf_index &cf_i)
+{
+
+	if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("return") != cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
+	{
+		cf_i.redirect_path = cf.v_s[cf_i.server].v_l[cf_i.location].m_location["return"][1];
+		throw stoi(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["return"][0]);
+	}
+}
 
 void exec_header(config &cf, request::value_type &fd_data, conf_index &cf_i, std::map<std::string, std::string> &m_mt)
 {
@@ -230,34 +427,9 @@ void exec_header(config &cf, request::value_type &fd_data, conf_index &cf_i, std
 			//std::cout << "에러처리찾기 : keep-alive아닐때 처리. close같은 옵션도 있던데 해야햐ㅏㄹ까?" << std::endl;
 	}
 	find_cf_location_i(cf, fd_data, cf_i);
-	confirmed_root_path(cf, cf_i);
-
-	if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("index") == cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
-		cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"].push_back("index.html");
-	for(int cnt = 0; cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"].size(); cnt++)
-	{
-		cf_i.file_path = cf_i.root_path + cf_i.location_path + "/" +  cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt];
-		if(access(cf_i.file_path.c_str(),F_OK) == 0)
-		{
-			//std::cout << "파일이 존재 합니다." << std::endl;
-			for(int str_i = cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt].size() - 1; str_i > 0; str_i--)
-			{
-				if(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt][str_i] == '.')
-				{
-					if(m_mt.find(cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt].substr(str_i + 1)) != m_mt.end())
-					{
-						cf_i.file_type = m_mt[cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][cnt].substr(str_i + 1)];
-						break;
-					}
-					else
-						throw 400;
-				}
-			}
-			break;
-		}
-		if (cnt + 1 == cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"].size())
-			throw 404;
-	}
+	exec_redirection(cf ,cf_i);
+	if(confirmed_root_path(cf, cf_i) == "location is folder")
+		confirmed_file_path_and_file_type(cf, cf_i, m_mt);
 }
 
 void exec_body()
@@ -267,6 +439,161 @@ void exec_body()
 class response_data{
 
 };
+
+void make_request(int &error_code, std::string &request_msg, conf_index &cf_i)
+{
+	std::ifstream readFile;
+
+	if(200 <= error_code && 400 > error_code)
+	{
+		request_msg += "Connection: " + cf_i.Connection + "\r\n";
+		if(cf_i.autoindex_flag == 1)
+			readFile.open("./html_file/autoindex.html");
+		else
+			readFile.open(cf_i.file_path);
+	}
+	else if(error_code == -900) //error_page
+	{
+		request_msg += "Connection: keep-alive\r\n";
+		readFile.open(cf_i.file_path);
+	}
+	else
+	{
+		request_msg += "Connection: keep-alive\r\n";
+		readFile.open((std::string)"./html_file/" + std::to_string(error_code) + ".html");
+	}
+
+	std::string readLine ="";
+	std::string file_data = "";
+	if (readFile.is_open())
+	{
+		while (getline(readFile, readLine))
+			file_data += readLine + "\n";
+		readFile.close();
+	}
+	else
+		throw open_fail();
+	if(200 <= error_code && 400 > error_code)
+	{
+        if(cf_i.autoindex_flag == 1) // cf_i.root_path + cf_i.request_url_remaining 이 폴더 일때만 탐.. 
+        {
+			DIR * dir = NULL;
+			struct dirent * entry;
+			struct stat buf;
+			std::string path = cf_i.root_path + cf_i.request_url_remaining;
+			std::cout << "path : " << path << std::endl;
+			std::string path_list = "";
+			if( (dir = opendir(path.c_str())) == NULL)
+				throw root_and_location_error();
+			while( (entry = readdir(dir)) != NULL)
+			{
+				std::string s_tmp (entry->d_name);
+				std::string tmp_d_name (entry->d_name);
+				s_tmp = path + "/" + s_tmp;
+				stat(s_tmp.c_str(), &buf);
+				if(S_ISREG(buf.st_mode))
+				{
+					//	printf("FILE    ");
+				}
+				else if(S_ISDIR(buf.st_mode))
+				{
+					tmp_d_name += "/";
+					//printf("DIR     ");
+				}
+				else
+					std::cout << "???  이거 파일도 아니고, 폴더도 아닌게 있어?   " << std::endl;
+				path_list += "<a href=\"";
+				path_list += tmp_d_name;
+				path_list += "\">" + tmp_d_name + "</a>";
+				for(int zz = tmp_d_name.size(); zz <= 40; zz++)
+					path_list += " ";
+	//			printf("%s      ", entry->d_name);
+	//			printf("Last status change: %s", ctime(&buf.st_ctime)); 
+	//			printf("Last file access: %s", ctime(&buf.st_atime));
+
+				std::string b_size_tmp;
+				if(S_ISREG(buf.st_mode))
+					b_size_tmp = std::to_string(buf.st_size);
+				else b_size_tmp = "-";
+				path_list += b_size_tmp;
+				for(int zz = b_size_tmp.size(); zz <= 20; zz++)
+					path_list += " " ;
+				path_list += std::string(ctime(&buf.st_mtime));
+			}
+			closedir(dir);
+			std::cout << std::endl;
+			std::string find_str1 = "$1";
+			std::string find_str2 = "$2";
+			file_data.replace(file_data.find(find_str1), find_str1.size(), cf_i.root_path + cf_i.request_url_remaining);
+			file_data.replace(file_data.find(find_str1), find_str1.size(), cf_i.root_path + cf_i.request_url_remaining);
+			file_data.replace(file_data.find(find_str2), find_str2.size(), path_list);
+		}
+		request_msg += "Content-Length: " + std::to_string(file_data.size()) + "\r\n";
+		request_msg += "Content-type: " + cf_i.file_type + "\r\n";
+	}
+	else
+	{
+		//error_page는 html파일만 보냄..
+		request_msg += "Content-Length: " + std::to_string(file_data.size()) + "\r\n";
+		request_msg += "Content-type: text/html\r\n";
+	}
+	request_msg += "\r\n";
+	request_msg += file_data;
+}
+
+void exec_error_page(conf_index &cf_i, config &cf, int &error_code, std::vector<std::string> &v_error_page, std::string &request_msg, std::map<int, std::string> &m_state_code)
+{
+	std::ifstream readFile;
+
+	for(int i = 0; i < v_error_page.size() - 1; i++)
+	{
+		if(stoi(v_error_page[i]) == error_code)
+		{
+			readFile.open(cf_i.root_path + cf_i.request_url_remaining + v_error_page[v_error_page.size() - 1]);
+			//std::cout << cf_i.root_path + cf_i.request_url_remaining + v_error_page[v_error_page.size() - 1]<< std::endl;
+			if (readFile.is_open())
+			{
+				if(413 == check_filesize(readFile, cf_i, cf))
+				{
+					error_code = 413;
+					request_msg = (std::string)"HTTP/1.1 " + std::to_string(error_code) + " " + m_state_code[error_code] + "\r\n";
+				}
+				else
+				{
+					error_code = -900;
+					cf_i.file_path = cf_i.root_path + cf_i.request_url_remaining + v_error_page[v_error_page.size() - 1];
+				}
+				readFile.close();
+			}
+			else ; //error_page파일 안열리면 그냥 에러코드를 출력하면 됨.
+			break;
+		}
+	}
+}
+
+
+
+void error_page(int &error_code, conf_index &cf_i, config &cf, std::string &request_msg, std::map<int, std::string> &m_state_code)
+		
+{
+	if (cf_i.root_path == "")
+		cf_i.root_path = "./html_file";
+	if (cf_i.server != -1 && cf_i.location != -1 && cf.v_s[cf_i.server].v_l[cf_i.location].m_location.find("error_page") != cf.v_s[cf_i.server].v_l[cf_i.location].m_location.end())
+	{
+		exec_error_page(cf_i, cf, error_code, cf.v_s[cf_i.server].v_l[cf_i.location].m_location["error_page"], request_msg, m_state_code);	
+	}
+	else if (cf_i.server != -1)
+	{
+		exec_error_page(cf_i, cf, error_code, cf.v_s[cf_i.server].v_error_page[0].second, request_msg, m_state_code);	
+	}
+
+}
+void make_request_redirect(std::string &request_msg, conf_index &cf_i)
+{
+	request_msg += (std::string)"Content-Type: text/html" + "\r\n";
+	request_msg += (std::string)"Connection: keep-alive" + "\r\n";
+	request_msg += (std::string)"Location: " + cf_i.redirect_path + "\r\n" + "\r\n";
+}
 
 void    exec_request(config &cf, fd_set &write_fds, request *rq, std::string &request_msg)
 {
@@ -291,59 +618,24 @@ void    exec_request(config &cf, fd_set &write_fds, request *rq, std::string &re
 	    if (!rq->is_invalid(it)) //일단 그 값이 유효할 때만 출력 -> 나중에         유효하지 않으면 해당되는 에러 페이지 호출하도록
 	        rq->print();
 		try{
-			exec_method(cf, it);
 			exec_header(cf, *it, cf_i, m_mt);
+			exec_method(cf, it, cf_i);
 			exec_body();
 			throw 200;
 		}
 		catch (int error_code)
 		{
-			//HTTP/1.1 200 OK
-			//std::cout << "============== error_code :  " << error_code << std::endl;
+			//std::cout << "rrbbrbr " << std::endl;
 			request_msg = (std::string)"HTTP/1.1 " + std::to_string(error_code) + " " + m_state_code[error_code] + "\r\n";
-
-			std::ifstream readFile;
-			if(200 <= error_code && 400 > error_code)
-			{
-				request_msg += "Connection: " + cf_i.Connection + "\r\n";
-				readFile.open(cf_i.file_path);
-			}
+			if(cf_i.redirect_path != "")
+				make_request_redirect(request_msg, cf_i);
 			else
 			{
-				request_msg += "Connection: keep-alive\r\n";
-				readFile.open((std::string)"./html_file/" + std::to_string(error_code) + ".html");
+				if(cf_i.autoindex_flag != 1)
+					error_page(error_code, cf_i, cf, request_msg, m_state_code);
+				make_request(error_code, request_msg, cf_i);
 			}
-
-			std::string readLine ="";
-			std::string file_data = "";
-			if (readFile.is_open())
-			{
-				while (getline(readFile, readLine))
-					file_data += readLine + "\n";
-				readFile.close();
-			}
-			else
-			{
-				std::cout << "구린내가 난다.! " << std::endl;
-				throw open_fail();
-			}
-			if(200 <= error_code && 400 > error_code)
-			{
-				request_msg += "Content-Length: " + std::to_string(file_data.size()) + "\r\n";
-				request_msg += "Content-type: " + cf_i.file_type + "\r\n";
-			}
-			else
-			{
-				request_msg += "Content-Length: " + std::to_string(file_data.size()) + "\r\n";
-				request_msg += "Content-type: text/html\r\n";
-			}
-
-			request_msg += "\r\n";
-			request_msg += file_data;
 			std::cout << request_msg << std::endl;
-			std::cout << std::endl;
-			std::cout << std::endl;
-		//	std::cout << " =====  rkwmdk!!!!!! ======\n" << cf.v_s[cf_i.server].v_l[cf_i.location].m_location["root"][0] + cf.v_s[cf_i.server].location_path[cf_i.location] + cf.v_s[cf_i.server].v_l[cf_i.location].m_location["index"][0] << "\n" << std::endl;
 		}
 		catch (std::exception &e)
 		{

--- a/html_file/autoindex.html
+++ b/html_file/autoindex.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<style>
+		@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;900&display=swap');
+		html {
+			font-family: 'Roboto';
+		}
+		body {
+			padding: 30px;
+		}
+		h1, h2 {
+			font-weight: 400;
+			margin: 0;
+		}
+		h1 > span {
+			font-weight: 900;
+		}
+		ul > li {
+			font-size: 20px;
+		}
+		a {
+			color: black;
+			text-decoration: none;
+		}
+	</style>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Webserv index of $1</title>
+</head>
+<body>
+	<h1>Webserv index of <span>$1</span></h1>
+	<hr><pre>$2
+	</pre><hr>
+	<ul>
+	</ul>
+</body>
+</html>

--- a/html_file/error_page_404.html
+++ b/html_file/error_page_404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<title>error_page 404 Not Found</title>
+	<body>
+		<div>
+			<H1>error_page 404 Not Found</H1>
+			<p>Unable to find a representation of the requested resource</p>
+		</div>
+	</body>
+</html>

--- a/html_file/hoylee/index.html
+++ b/html_file/hoylee/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to Webserv!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to Webserv!</h1>
+<p>If you see this page, the Webserv is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>

--- a/include/error.hpp
+++ b/include/error.hpp
@@ -36,4 +36,22 @@ struct config_error_root : std::exception {
   const char* what() const throw() {return "configfile don't have root";}
 };
 
+struct config_error_allow_methods : std::exception {
+  const char* what() const throw() {return "configfile wrong data for allow_methods";}
+};
+struct config_error_error_page : std::exception {
+  const char* what() const throw() {return "configfile wrong data for error_page";}
+};
+struct config_error_client_max : std::exception {
+  const char* what() const throw() {return "configfile wrong data for client_max_body_size";}
+};
+struct config_error_return : std::exception {
+  const char* what() const throw() {return "configfile wrong data for return\nreturn 번호 : 영구(301, 308), 임시(302, 303, 307, 308)";}
+};
+
+struct root_and_location_error : std::exception {
+  const char* what() const throw() {return "root랑 location 경로 안열림!";}
+};
+
+
 #endif

--- a/include/parsing.hpp
+++ b/include/parsing.hpp
@@ -76,7 +76,7 @@ public :
 		file_name = _file_name;
 		std::string s_invalid_key[] = {"location", "listen", "error_page"};
 		std::string l_invalid_key[] = { "error_page", "allow_methods", \
-				"request_max_body_size", "root", "index", "auto_index", \
+				"client_max_body_size", "root", "index", "auto_index", \
 				"cgi_extension", "auth_key", "client_body_buffer_size", "upload_path", "return"};
 
 	v_server_invalid_key.insert(v_server_invalid_key.begin(), s_invalid_key, s_invalid_key + sizeof(s_invalid_key) / sizeof(std::string));

--- a/webserv.conf
+++ b/webserv.conf
@@ -11,43 +11,48 @@ server
 
 	#error_page 404aaa errors/404.html;  이것도 가능.
 
-	error_page 404 ./tests/www/error404.html
+	error_page 300 405 304 404 /error_page_404.html
 	location /						# / 로케이션은 반드시 존재해야합니다. (디폴트서버)
 	{
-		error_page 404 ./tests/www/error404.html
+		error_page 404 /error_page_404.html
 #error_page 404 ./tests/www/error40aaaaa4.html
 		#error_pgee 405 ./tests/www/error405.html #이거 아마 오타인듯.
 		allow_methods GET POST
-		request_max_body_size	2048
+		client_max_body_size 2048
 		root ./html_file
-		index index.html index2.html
+		index index.html
 		auto_index on
 		cgi_extension .bla
 		auth_key hyeonskizzangzzangman:1234
-		#client_body_buffer_size 1000이렇게 올수도 있음.
+		#client_body_buffer_size 1000M #이렇게 올수도 있음.
 		#upload_path /tmp/
-		#return 301 https://www.naver.com 이건 리다이렉션할떄 올수 있음.
+#return 302 https://www.naver.com #이건 리다이렉션할떄 올수 있음.
 		#cgi_path_info : 구현안됨. 말봉님 코드에는 있는데, nginx 공홈에는 없음. 
 	}
-
-	location /2/
+	location /abcd/efgh/
 	{
-		root ./tests/www/
-		index second.html
+		root ./test/www/
+		index index.html
+	}
+
+	location /2////
+	{
+		root ./html_file
+		index index.html
 		auto_index on
 		auth_key juyangzzangzzangman:1234
 	}
 
-	location /virtual/
+	location /virtual//siej///iowej
 	{
 		root ./tests/www/
 		cgi_extension .bla
 		auth_key kileezzangzzangman:1234
 	}
 
-	location /post/
+	location v
 	{
-		allow_methods GET POST PUT DELETE
+		allow_methods GET POST DELETE
 		root ./tests/www/tmp/
 		client_body_buffer_size 1000
 		auth_key jayunzzangzzangman:1234
@@ -55,7 +60,7 @@ server
 
 	location /post/tmp/
 	{
-		allow_methods POST PUT
+		allow_methods POST
 		root ./test/www/tmp/
 		upload_path /tmp/
 		auth_key hyeonski_zzang:1234

--- a/webserv.cpp
+++ b/webserv.cpp
@@ -81,8 +81,7 @@ int		main(void)
 	{
 		config cf("webserv.conf");
 		config_parsing(cf);
-		//print_cf_data(cf); //이걸로 cf출력 볼수 있습니다. 
-
+//		print_cf_data(cf); //이걸로 cf출력 볼수 있습니다. 
 		exec_webserv(cf); //나중에 config 받아서~
 	}
 	catch(const std::exception& e)


### PR DESCRIPTION
# 1. webserv 기능추가
### 1.  allow_methods 
 * conf에 없으면 모든 method를 허용합니다. 
 * allow_methods GET, POST 왼쪽과 같이 conf 파일에서 설정 할 수 있습니다. (클라이언트에서 GET, POST를 제외한 메소드 요청이 들어오면 404 에러를 띄웁니다.)

### 2. client_max_body_size 
 * 클라이언트로 보낼 용량을 제한합니다. 없으면 제한이 없습니다. 
 * 2048인 경우 서버가 클라이언트로 2048M 까지 보낼수 있습니다.
 * client_max_body_size 2048 또는 client_max_body_size 2048M로 사용가능합니다. 
 
### 3. auto_index 
 * 해당 경로에 파일이 없으면 list를 띄웁니다.
 * auto_index가 있으면 해당 경로에 index파일이 없어도 error_page 작동하지 않습니다. (리스트 띄우면 되니까!)
 * auto_index on 또는 off 입니다!!!

# 2. 파일경로 변경
 * 기존 root + location + index 에서 root + (url - location) + index 로 변경했습니다. 
 * 만약 url이 파일이면 index파일이 아닌 url 파일을 열게 됩니다.
 * 경로에 없으면 404 또는 403을 띄웁니다! 

# 3. 그 외
 * 쿼리스티링을 따로 빼놨습니다. 
 * conf 파일에서 파싱 기능 추가 및 파싱벨류값 일부 수정했습니다! 

